### PR TITLE
Update LinuxServer Bookstack from v23.02.2-ls71 to v24.10.1-ls174

### DIFF
--- a/bookstack-helm/values.yaml
+++ b/bookstack-helm/values.yaml
@@ -51,7 +51,7 @@ bookstack:
 image:
   repository: lscr.io/linuxserver/bookstack
   pullPolicy: IfNotPresent
-  tag: "v23.02.2-ls71"
+  tag: "v24.10.1-ls174"
 
 db_image:
   repository: lscr.io/linuxserver/mariadb


### PR DESCRIPTION
Planning to deploy to a test environment, confirm functionality, and then deploy to production