### PR TITLE
Update LinuxServer Bookstack from v23.02.2-ls71 to v24.10.1-ls174

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [ master, john/versionupdate ]
+    branches: [ master ]
   workflow_dispatch:
     branches:
       - master

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, john/versionupdate ]
   workflow_dispatch:
     branches:
       - master

--- a/bookstack-helm/values.yaml
+++ b/bookstack-helm/values.yaml
@@ -51,7 +51,7 @@ bookstack:
 image:
   repository: lscr.io/linuxserver/bookstack
   pullPolicy: IfNotPresent
-  tag: "v23.02.2-ls71"
+  tag: "v24.10.1-ls174"
 
 db_image:
   repository: lscr.io/linuxserver/mariadb


### PR DESCRIPTION
Also added the GitHub Actions code to deploy from my branch to dev, went to https://devwiki.mesh.nycmesh.net/ to confirm things worked (logged in, downloaded attachments, navigated to webpages), and then removed the GitHub Actions code. 