### PR TITLE
Update LinuxServer Bookstack from v24.10.3-ls183 to v24.12.1-ls190

### DIFF
--- a/bookstack-helm/values.yaml
+++ b/bookstack-helm/values.yaml
@@ -51,7 +51,7 @@ bookstack:
 image:
   repository: lscr.io/linuxserver/bookstack
   pullPolicy: IfNotPresent
-  tag: "v24.10.3-ls183"
+  tag: "v24.12.1-ls190"
 
 db_image:
   repository: lscr.io/linuxserver/mariadb


### PR DESCRIPTION
Routine version update. Similar to https://github.com/nycmeshnet/wiki-infra/pull/15. Will approve deployment to dev, check https://devwiki.mesh.nycmesh.net/ and then continue