### PR TITLE
Update LinuxServer Bookstack from v24.12.1-ls190 to v25.02-ls195

### DIFF
--- a/bookstack-helm/values.yaml
+++ b/bookstack-helm/values.yaml
@@ -51,7 +51,7 @@ bookstack:
 image:
   repository: lscr.io/linuxserver/bookstack
   pullPolicy: IfNotPresent
-  tag: "v24.12.1-ls190"
+  tag: "v25.02-ls195"
 
 db_image:
   repository: lscr.io/linuxserver/mariadb


### PR DESCRIPTION
Routine version update. Similar to #16. Will approve deployment to dev, check https://devwiki.mesh.nycmesh.net/ and then continue