### PR TITLE
Download more RAM

### DIFF
--- a/bookstack-helm/values.yaml
+++ b/bookstack-helm/values.yaml
@@ -39,7 +39,7 @@ bookstack:
   resources:
     requests:
       cpu: 512m
-      memory: 384Mi
+      memory: 512Mi
   enableReadinessProbe: false
   readinessProbeInitialDelaySeconds: 20
   enableLivenessProbe: true


### PR DESCRIPTION
https://github.com/BookStackApp/BookStack/issues/5039

Ah, this seems to be the issue. Just the thumbnail generation is failing, the rest works fine.
Apparently increasing the RAM is the way to fix this.

Bumping RAM by 128MB to see if it helps at all